### PR TITLE
Allow __invoke() without params

### DIFF
--- a/src/AssetAction.php
+++ b/src/AssetAction.php
@@ -59,6 +59,7 @@ class AssetAction
     public function __invoke($vendor, $package, $file)
     {
         $asset = $this->domain->getAsset($vendor, $package, $file);
-        return $this->responder->__invoke($asset->path, $asset->type);
+        $this->responder->setData(array('asset' => $asset));
+        return $this->responder;
     }
 }

--- a/src/AssetResponder.php
+++ b/src/AssetResponder.php
@@ -22,6 +22,15 @@ class AssetResponder
 
     /**
      *
+     * Data for modifying the response.
+     *
+     * @var object
+     *
+     */
+    protected $data;
+
+    /**
+     *
      * Constructor.
      *
      * @param Response $response A web response object.
@@ -30,6 +39,34 @@ class AssetResponder
     public function __construct(Response $response)
     {
         $this->response = $response;
+        $this->data = (object) array();
+    }
+
+    /**
+     *
+     * Sets data for modifying the response.
+     *
+     * @param mixed $data Data for modifying the response; will be cast to an
+     * object.
+     *
+     * @return null
+     *
+     */
+    public function setData($data)
+    {
+        $this->data = (object) $data;
+    }
+
+    /**
+     *
+     * Gets data for modifying the response.
+     *
+     * @return object
+     *
+     */
+    public function getData()
+    {
+        return $this->data;
     }
 
     /**
@@ -43,10 +80,13 @@ class AssetResponder
      * @return Response
      *
      */
-    public function __invoke($path, $type)
+    public function __invoke()
     {
-        if ($path) {
-            $this->ok($path, $type);
+        if (isset($this->data->asset->path)) {
+            $this->ok(
+                $this->data->asset->path,
+                $this->data->asset->type
+            );
         } else {
             $this->notFound();
         }

--- a/tests/src/AssetActionTest.php
+++ b/tests/src/AssetActionTest.php
@@ -25,24 +25,17 @@ class AssetActionTest extends \PHPUnit_Framework_TestCase
 
     public function test__invoke()
     {
-        $response = $this->action->__invoke('vendor', 'package', 'style.css');
+        $responder = $this->action->__invoke('vendor', 'package', 'style.css');
 
-        $this->assertInstanceOf('Aura\Web\Response', $response);
+        $this->assertInstanceOf('Aura\Asset_Bundle\AssetResponder', $responder);
 
-        $actual = $response->status->getCode();
-        $this->assertSame(200, $actual);
-
-        $expect = 'text/css';
-        $actual = $response->content->getType();
-        $this->assertSame($expect, $actual);
-
-        $content = $response->content->get();
-        ob_start();
-        $content();
-        $actual = ob_get_clean();
-
-        $path = $this->asset_dir. DIRECTORY_SEPARATOR . 'style.css';
-        $expect = file_get_contents($path);
-        $this->assertSame($expect, $actual);
+        $actual = $responder->getData();
+        $expect = (object) array(
+            'asset' => (object) array(
+                'path' => $this->asset_dir . DIRECTORY_SEPARATOR . 'style.css',
+                'type' => 'text/css',
+            )
+        );
+        $this->assertEquals($expect, $actual);
     }
 }

--- a/tests/src/AssetResponderTest.php
+++ b/tests/src/AssetResponderTest.php
@@ -21,7 +21,17 @@ class AssetResponderTest extends \PHPUnit_Framework_TestCase
     {
         $path = $this->asset_dir. DIRECTORY_SEPARATOR . 'style.css';
         $type = 'text/css';
-        $response = $this->responder->__invoke($path, $type);
+
+        $asset = (object) array(
+            'path' => $path,
+            'type' => $type,
+        );
+
+        $this->responder->setData(array(
+            'asset' => $asset,
+        ));
+
+        $response = $this->responder->__invoke();
 
         $this->assertInstanceOf('Aura\Web\Response', $response);
 


### PR DESCRIPTION
@harikt -- I was wrong to remove setData() from the responder before. This PR puts it back, so that the Action can return the Responder, and the Dispatcher can then invoke that Responder as part of the dispatch process.
